### PR TITLE
Feat/Api Add One Time Token

### DIFF
--- a/apps/api/src/auth/index.ts
+++ b/apps/api/src/auth/index.ts
@@ -1,7 +1,7 @@
 import { stripe } from "@better-auth/stripe";
 import { betterAuth } from "better-auth";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
-import { emailOTP, openAPI } from "better-auth/plugins";
+import { emailOTP, openAPI, oneTimeToken } from "better-auth/plugins";
 import Stripe from "stripe";
 import { db } from "../db/index.js";
 import { sendOtp } from "../utils/mail.utils.js";
@@ -19,18 +19,18 @@ export const auth: ReturnType<typeof betterAuth> = betterAuth({
   trustedOrigins: ["*"],
   ...(env.NODE_ENV === "production"
     ? {
-        advanced: {
-          crossSubDomainCookies: {
-            enabled: true,
-            domain: ".getgrinta.com",
-          },
-          defaultCookieAttributes: {
-            secure: true,
-            httpOnly: true,
-            sameSite: "none",
-          },
+      advanced: {
+        crossSubDomainCookies: {
+          enabled: true,
+          domain: ".getgrinta.com",
         },
-      }
+        defaultCookieAttributes: {
+          secure: true,
+          httpOnly: true,
+          sameSite: "none",
+        },
+      },
+    }
     : {}),
   database: drizzleAdapter(db, {
     provider: "pg",
@@ -99,5 +99,6 @@ export const auth: ReturnType<typeof betterAuth> = betterAuth({
       },
     }),
     openAPI(),
+    oneTimeToken(),
   ],
 });

--- a/apps/extension/src/lib/auth.ts
+++ b/apps/extension/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { stripeClient } from "@better-auth/stripe/client";
-import { emailOTPClient } from "better-auth/client/plugins";
+import { emailOTPClient, oneTimeTokenClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/svelte";
 import type { AppType } from "@getgrinta/api";
 import { hc } from "hono/client";
@@ -15,5 +15,6 @@ export const authClient = createAuthClient({
     stripeClient({
       subscription: true,
     }),
+    oneTimeTokenClient()
   ],
 });

--- a/apps/extension/src/lib/components/sidebar-tab-context-menu.svelte
+++ b/apps/extension/src/lib/components/sidebar-tab-context-menu.svelte
@@ -4,10 +4,10 @@
   import {
     CopyPlusIcon,
     ListXIcon,
-    PinIcon,
     PlusIcon,
     RefreshCwIcon,
     StarIcon,
+    Volume2Icon,
     VolumeOffIcon,
     XIcon,
   } from "lucide-svelte";
@@ -15,48 +15,43 @@
 
   type Props = ContextMenu.RootProps & {
     children: Snippet;
-    tabId: number;
+    tab: chrome.tabs.Tab;
   };
 
-  let { open = $bindable(false), tabId, children }: Props = $props();
+  let { open = $bindable(false), tab, children }: Props = $props();
 
   function handleNewTab() {
-    sendMessage("grinta_newTab", { tabId }, "background");
+    sendMessage("grinta_newTab", { tabId: tab.id }, "background");
     open = false;
   }
 
   function handleReload() {
-    sendMessage("grinta_reloadTab", { tabId }, "background");
+    sendMessage("grinta_reloadTab", { tabId: tab.id }, "background");
     open = false;
   }
 
   function handleDuplicate() {
-    sendMessage("grinta_duplicateTab", { tabId }, "background");
-    open = false;
-  }
-
-  function handlePin() {
-    sendMessage("grinta_togglePinTab", { tabId }, "background");
+    sendMessage("grinta_duplicateTab", { tabId: tab.id }, "background");
     open = false;
   }
 
   function handleMute() {
-    sendMessage("grinta_toggleMuteTab", { tabId }, "background");
+    sendMessage("grinta_toggleMuteTab", { tabId: tab.id }, "background");
     open = false;
   }
 
   function handleClose() {
-    sendMessage("grinta_closeTab", { tabId }, "background");
+    sendMessage("grinta_closeTab", { tabId: tab.id }, "background");
     open = false;
   }
 
   function handleCloseOtherTabs() {
-    sendMessage("grinta_closeOtherTabs", { tabId }, "background");
+    sendMessage("grinta_closeOtherTabs", { tabId: tab.id }, "background");
     open = false;
   }
 
   function handleAddToEssentials() {
-    sendMessage("grinta_addToEssentials", { tabId }, "background");
+    sendMessage("grinta_addToEssentials", { tabId: tab.id }, "background");
     open = false;
   }
 </script>
@@ -87,15 +82,14 @@
           </a>
         </li>
         <li>
-          <a onclick={handlePin}>
-            <PinIcon size={16} />
-            <span>Pin</span>
-          </a>
-        </li>
-        <li>
           <a onclick={handleMute}>
-            <VolumeOffIcon size={16} />
-            <span>Mute</span>
+            {#if tab.mutedInfo?.muted}
+              <Volume2Icon size={16} />
+              <span>Unmute</span>
+            {:else}
+              <VolumeOffIcon size={16} />
+              <span>Mute</span>
+            {/if}
           </a>
         </li>
         <li>

--- a/apps/extension/src/lib/components/sidebar-tab.svelte
+++ b/apps/extension/src/lib/components/sidebar-tab.svelte
@@ -41,7 +41,7 @@
   }
 </script>
 
-<SidebarTabContextMenu tabId={tab.id}>
+<SidebarTabContextMenu {tab}>
   <!-- svelte-ignore a11y_no_noninteractive_element_to_interactive_role -->
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <li

--- a/apps/extension/src/lib/components/space-button.svelte
+++ b/apps/extension/src/lib/components/space-button.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+  import { tabsStore } from "$lib/store/tabs.svelte";
+  import { draggable, droppable } from "@thisux/sveltednd";
+  import clsx from "clsx";
+  import {
+    CircleDotIcon,
+    CircleIcon,
+    CircleDotDashedIcon,
+    CircleDashedIcon,
+    StarIcon,
+    XIcon,
+    TrashIcon,
+  } from "lucide-svelte";
+  import colors from "tailwindcss/colors";
+  import { sendMessage } from "webext-bridge/popup";
+  import { onClickOutside } from "runed";
+
+  let { space, draggableConfig, droppableConfig } = $props<{
+    space: chrome.tabGroups.TabGroup;
+    draggableConfig: object;
+    droppableConfig: object;
+  }>();
+  let dropdownElement = $state<HTMLUListElement>();
+  let contextMenuOpen = $state(false);
+
+  const bookmarks = $derived(
+    space.title ? tabsStore.essentials[space.title] : undefined,
+  );
+
+  function setContextMenuOpen(open: boolean) {
+    contextMenuOpen = open;
+  }
+
+  function handleRightClick(event: MouseEvent) {
+    event.preventDefault();
+    setContextMenuOpen(true);
+  }
+
+  function activateSpace(event: MouseEvent, groupId: number) {
+    event.preventDefault();
+    event.stopPropagation();
+    return sendMessage("grinta_activateGroup", { groupId }, "background");
+  }
+
+  const hex = colors[space.color as never]?.[500] ?? colors.gray[500];
+
+  async function handleCloseGroup() {
+    await sendMessage(
+      "grinta_deleteGroup",
+      { groupId: space.id },
+      "background",
+    );
+    setContextMenuOpen(false);
+  }
+
+  async function handleMakeEssential() {
+    await sendMessage(
+      "grinta_createEssentialsFolder",
+      { title: space.title },
+      "background",
+    );
+    setContextMenuOpen(false);
+  }
+
+  async function handleRemoveEssential() {
+    const folder = (await sendMessage(
+      "grinta_findEssentialsFolder",
+      { title: space.title },
+      "background",
+    )) as unknown as chrome.bookmarks.BookmarkTreeNode;
+    if (!folder) return;
+    await sendMessage(
+      "grinta_deleteFolder",
+      { folderId: folder.id },
+      "background",
+    );
+    await sendMessage(
+      "grinta_deleteGroup",
+      { groupId: space.id },
+      "background",
+    );
+    setContextMenuOpen(false);
+  }
+
+  onClickOutside(
+    () => dropdownElement,
+    () => setContextMenuOpen(false),
+  );
+</script>
+
+<div class="tooltip tooltip-top" data-tip={space.title}>
+  <details
+    bind:open={contextMenuOpen}
+    class={clsx("dropdown dropdown-top dropdown-center")}
+  >
+    <summary
+      class={clsx("btn btn-sm btn-ghost btn-square", `text-${space.color}-500`)}
+      use:draggable={draggableConfig}
+      use:droppable={droppableConfig}
+      onclick={(event) => activateSpace(event, space.id)}
+      oncontextmenu={handleRightClick}
+    >
+      {#if bookmarks}
+        {#if space.id === tabsStore.currentSpaceId}
+          <CircleDotIcon size={24} color={hex} />
+        {:else}
+          <CircleIcon size={24} color={hex} />
+        {/if}
+      {:else if space.id === tabsStore.currentSpaceId}
+        <CircleDotDashedIcon size={24} color={hex} />
+      {:else}
+        <CircleDashedIcon size={24} color={hex} />
+      {/if}
+    </summary>
+    <ul
+      bind:this={dropdownElement}
+      class="dropdown-content menu bg-base-300 rounded-box z-1 w-52 p-2 shadow-sm"
+    >
+      {#if bookmarks}
+        <li>
+          <button class="text-red-500" onclick={handleRemoveEssential}>
+            <TrashIcon size={16} />
+            <span>Remove</span>
+          </button>
+        </li>
+      {:else}
+        <li>
+          <button onclick={handleMakeEssential}>
+            <StarIcon size={16} />
+            <span>Make Essential</span>
+          </button>
+        </li>
+      {/if}
+      <li>
+        <button onclick={handleCloseGroup}>
+          <XIcon size={16} />
+          <span>Close</span>
+        </button>
+      </li>
+    </ul>
+  </details>
+</div>

--- a/apps/extension/src/lib/components/space-essential-context-menu.svelte
+++ b/apps/extension/src/lib/components/space-essential-context-menu.svelte
@@ -19,7 +19,7 @@
 </script>
 
 <ContextMenu.Root bind:open>
-  <ContextMenu.Trigger class="w-full flex">
+  <ContextMenu.Trigger class="w-full flex flex-1">
     {@render children()}
   </ContextMenu.Trigger>
   <ContextMenu.Portal>

--- a/apps/extension/src/lib/components/space-essentials.svelte
+++ b/apps/extension/src/lib/components/space-essentials.svelte
@@ -15,10 +15,6 @@
   const currentOrigin = $derived(
     currentTab?.url ? new URL(currentTab.url).origin : undefined,
   );
-  const currentSpace = $derived(
-    tabsStore.groups.find((group) => group.id === currentTab?.groupId),
-  );
-
   function handleClick(essential: chrome.bookmarks.BookmarkTreeNode) {
     return sendMessage(
       "grinta_openEssential",
@@ -36,7 +32,7 @@
       {
         dragIndex,
         dropIndex,
-        folder: currentSpace?.title ?? "",
+        folder: tabsStore.currentSpace?.title ?? "",
       },
       "background",
     );
@@ -51,7 +47,10 @@
   }
 </script>
 
-<div class="grid grid-cols-8 gap-1 mb-2" transition:slide>
+<div
+  class="grid grid-cols-6 sm:grid-cols-8 gap-1 mb-2 place-items-stretch"
+  transition:slide
+>
   {#each essentials as essential, index}
     {@const url = new URL(essential.url)}
     {@const active = currentOrigin === url.origin}
@@ -59,12 +58,16 @@
     {@const src =
       essentialTab?.favIconUrl ??
       `https://www.google.com/s2/favicons?domain=${url.hostname}`}
-    <SpaceEssentialContextMenu groupName={currentSpace?.title ?? ""} {index}>
-      <div class="tooltip tooltip-bottom" data-tip={essential.title}>
+    <SpaceEssentialContextMenu
+      groupName={tabsStore.currentSpace?.title ?? ""}
+      {index}
+    >
+      <div class="tooltip tooltip-bottom w-full" data-tip={essential.title}>
         <button
           class={clsx(
-            "btn btn-square relative overflow-hidden",
-            active && colorVariant[(currentSpace?.color as never) ?? "gray"],
+            "btn relative w-full overflow-hidden p-1",
+            active &&
+              colorVariant[(tabsStore.currentSpace?.color as never) ?? "gray"],
           )}
           onclick={() => handleClick(essential)}
           use:draggable={{
@@ -82,7 +85,7 @@
           />
           <img
             {src}
-            class="w-6 h-6 rounded-full bg-white pointer-events-none"
+            class="w-6 h-6 aspect-square rounded-full bg-white pointer-events-none"
           />
         </button>
       </div>

--- a/apps/extension/src/lib/components/space-picker.svelte
+++ b/apps/extension/src/lib/components/space-picker.svelte
@@ -1,37 +1,17 @@
 <script lang="ts">
-  import {
-    CircleDashedIcon,
-    CircleDotDashedIcon,
-    CircleDotIcon,
-    CircleFadingPlusIcon,
-    CircleIcon,
-    PlusIcon,
-  } from "lucide-svelte";
-  import { draggable, droppable, type DragDropState } from "@thisux/sveltednd";
+  import { CircleFadingPlusIcon, PlusIcon } from "lucide-svelte";
+  import { type DragDropState } from "@thisux/sveltednd";
   import { tabsStore } from "$lib/store/tabs.svelte";
   import { sendMessage } from "webext-bridge/popup";
-  import clsx from "clsx";
-  import colors from "tailwindcss/colors";
   import { rand } from "$lib/utils.svelte";
   import { TAB_COLOR } from "$lib/const";
-
-  const currentSpaceId = $derived(
-    tabsStore.tabs.find((tab) => tab.active)?.groupId,
-  );
+  import SpaceButton from "./space-button.svelte";
 
   const nonRestoredGroups = $derived(
     Object.keys(tabsStore.essentials).filter(
       (key) => !tabsStore.groups.some((group) => group.title === key),
     ),
   );
-
-  async function activateSpace(spaceId: number) {
-    await sendMessage(
-      "grinta_activateGroup",
-      { groupId: spaceId },
-      "background",
-    );
-  }
 
   async function handleDrop(state: DragDropState<{ index: number }>) {
     const { draggedItem, targetContainer } = state;
@@ -59,40 +39,18 @@
 >
   <div class="flex flex-1 group items-center justify-center">
     {#each tabsStore.groups as space, index}
-      {@const hex = colors[space.color as never]?.[500] ?? colors.gray[500]}
-      {@const bookmarks = space.title
-        ? tabsStore.essentials[space.title]
-        : undefined}
-      <div class="tooltip tooltip-top" data-tip={space.title}>
-        <button
-          class={clsx(
-            "btn btn-sm btn-ghost btn-square",
-            `text-${space.color}-500`,
-          )}
-          use:draggable={{
-            container: index.toString(),
-            dragData: { ...space, index },
-            interactive: ["[data-btn-close]", "[data-btn-activate]"],
-          }}
-          use:droppable={{
-            container: index.toString(),
-            callbacks: { onDrop: handleDrop as never },
-          }}
-          onclick={() => activateSpace(space.id)}
-        >
-          {#if bookmarks}
-            {#if space.id === currentSpaceId}
-              <CircleDotIcon size={24} color={hex} />
-            {:else}
-              <CircleIcon size={24} color={hex} />
-            {/if}
-          {:else if space.id === currentSpaceId}
-            <CircleDotDashedIcon size={24} color={hex} />
-          {:else}
-            <CircleDashedIcon size={24} color={hex} />
-          {/if}
-        </button>
-      </div>
+      <SpaceButton
+        {space}
+        draggableConfig={{
+          container: index.toString(),
+          dragData: { ...space, index },
+          interactive: ["[data-btn-close]", "[data-btn-activate]"],
+        }}
+        droppableConfig={{
+          container: index.toString(),
+          callbacks: { onDrop: handleDrop as never },
+        }}
+      />
     {/each}
     {#each nonRestoredGroups as title}
       <div class="tooltip tooltip-top" data-tip={title}>
@@ -105,10 +63,10 @@
       </div>
     {/each}
     <button
-      class="btn btn-sm gtn-ghost btn-square hidden group-hover:flex absolute right-2 top-1/2 -translate-y-1/2"
+      class="btn btn-sm gtn-ghost btn-square hidden group-hover:flex absolute right-2 top-2"
       onclick={() => tabsStore.addGroup()}
     >
-      <PlusIcon size={16} />
+      <PlusIcon size={16} class="pointer-events-none" />
     </button>
   </div>
 </div>

--- a/apps/extension/src/lib/store/tabs.svelte.ts
+++ b/apps/extension/src/lib/store/tabs.svelte.ts
@@ -13,6 +13,16 @@ export class TabsStore {
   openers = $state<Opener[]>([]);
   essentials = $state<Record<string, chrome.bookmarks.BookmarkTreeNode[]>>({});
 
+  currentTab = $derived(
+    this.tabs.find((tab) => tab.active),
+  );
+  currentSpaceId = $derived(
+    this.currentTab?.groupId,
+  );
+  currentSpace = $derived(
+    this.groups.find((group) => group.id === this.currentSpaceId),
+  );
+
   async addGroup() {
     const randomColor = rand(TAB_COLOR);
     await sendMessage("grinta_newGroup", {

--- a/apps/website/src/components/account-management.svelte
+++ b/apps/website/src/components/account-management.svelte
@@ -110,6 +110,8 @@
       <div class="grid grid-cols-2 gap-4 items-center">
         <p>Session</p>
         <button class="btn w-full" onclick={signOut}>Sign Out</button>
+        <p>One Time Token</p>
+        <a href="/code" class="btn w-full">Generate Token</a>
       </div>
     </div>
   </div>

--- a/apps/website/src/components/one-time-token.svelte
+++ b/apps/website/src/components/one-time-token.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { authClient } from "../lib/auth";
+  import { toast } from "svelte-sonner";
+
+  let code = $state<string>();
+
+  async function copy() {
+    await navigator.clipboard.writeText(code);
+    toast.success("Copied to clipboard");
+  }
+
+  onMount(() => {
+    authClient.oneTimeToken.generate().then((response) => {
+      code = response.data.token;
+    });
+  });
+</script>
+
+<div class="flex flex-col mt-24 items-center px-4 xl:px-0">
+  <div class="card lg:max-w-180 w-full bg-base-100 card-lg shadow-sm">
+    <div class="card-body gap-4">
+      <h2 class="card-title">One Time Token</h2>
+      <button type="button" class="input input-lg w-full" onclick={copy}
+        >{code}</button
+      >
+      <button type="button" class="btn btn-lg btn-primary" onclick={copy}
+        >Copy</button
+      >
+    </div>
+  </div>
+</div>

--- a/apps/website/src/lib/auth.ts
+++ b/apps/website/src/lib/auth.ts
@@ -1,5 +1,5 @@
 import { stripeClient } from "@better-auth/stripe/client";
-import { emailOTPClient } from "better-auth/client/plugins";
+import { emailOTPClient, oneTimeTokenClient } from "better-auth/client/plugins";
 import { createAuthClient } from "better-auth/svelte";
 import type { AppType } from "@getgrinta/api";
 import { hc } from "hono/client";
@@ -27,5 +27,6 @@ export const authClient = createAuthClient({
     stripeClient({
       subscription: true,
     }),
+    oneTimeTokenClient(),
   ],
 });

--- a/apps/website/src/pages/code.astro
+++ b/apps/website/src/pages/code.astro
@@ -1,0 +1,14 @@
+---
+// eslint-disable
+export const prerender = false;
+import BaseLayout from "../layouts/base-layout.astro";
+import OneTimeToken from "../components/one-time-token.svelte";
+
+if (!Astro.locals.session) {
+    return Astro.redirect("/sign-in");
+}
+---
+
+<BaseLayout title="One Time Token">
+    <OneTimeToken client:load />
+</BaseLayout>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced one-time token authentication support across the app, including the ability to generate and display one-time tokens in the account management section.
  - Added a dedicated "One Time Token" page for users to generate and copy tokens.
  - Added a new tab group (space) button component with drag-and-drop and context menu actions.

- **Improvements**
  - Simplified sign-in flow to use one-time token verification instead of multi-step email OTP.
  - Enhanced sidebar tab context menu to use full tab details, improved mute/unmute options, and removed the pin feature.
  - Modularized and improved the space picker with a new button component and streamlined drag-and-drop behavior.
  - Improved responsiveness and layout consistency in space essentials and related UI components.

- **Bug Fixes**
  - Ensured consistent access to current tab and space state throughout the extension.

- **Chores**
  - Updated authentication plugin configurations to support one-time tokens in both API and client applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->